### PR TITLE
Use a format compatible with the datepicker for date fields

### DIFF
--- a/app/inputs/date_time_input.rb
+++ b/app/inputs/date_time_input.rb
@@ -3,4 +3,24 @@ class DateTimeInput < SimpleForm::Inputs::Base
     input_html_options[:class] << "form-control"
     @builder.text_field(attribute_name, input_html_options)
   end
+
+  def input_html_options
+    existing_options = super
+
+    if existing_options.include? :value
+      existing_options
+    else
+      existing_options.merge({value: formatted_attribute_value(attribute_name)})
+    end
+  end
+
+  private
+
+  def formatted_attribute_value(attribute_name)
+    attribute_value(attribute_name).try(:strftime, '%e %B, %Y')
+  end
+
+  def attribute_value(attribute_name)
+    @builder.object.public_send(attribute_name)
+  end
 end


### PR DESCRIPTION
The dates in the date fields were using the default Y-m-d format which was
incompatible with the datepicker and it wasn't parsing them correctly.

This patch makes the date field display the date that's used by default by the
date picker.