### PR TITLE
Support newer materialize-css methods

### DIFF
--- a/app/assets/javascripts/materialize-form.js
+++ b/app/assets/javascripts/materialize-form.js
@@ -17,10 +17,17 @@ window.materializeForm = {
     $('input[type=checkbox]').addClass('filled-in')
   },
   initDate: function() {
-    $('input.date').pickadate({
-      selectMonths: true,
-      selectYears: 100
-    });
+    if (typeof $('input.date').pickadate === "function") {
+      $('input.date').pickadate({
+        selectMonths: true,
+        selectYears: 100
+      });
+    } else {
+      $('input.date').datepicker({
+        selectMonths: true,
+        selectYears: 100
+      });
+    }
   }
 }
 

--- a/app/assets/javascripts/materialize-form.js
+++ b/app/assets/javascripts/materialize-form.js
@@ -6,7 +6,12 @@ window.materializeForm = {
   },
   initSelect: function() {
     $('select[multiple="multiple"] option[value=""]').attr('disabled', true)
-    $('select').material_select()
+    if (typeof $('select').material_select === "function") {
+      $('select').material_select()
+    } else {
+      $('select').formSelect()
+    }
+
   },
   initCheckbox: function() {
     $('input[type=checkbox]').addClass('filled-in')


### PR DESCRIPTION
Hi! 

Love the gem, but I just upgraded to the latest version of [`materialize-css 1.0.0-rc.1 `](https://github.com/Dogfalo/materialize/tree/1.0.0-rc.1), and there are a few issues that need to be resolved.

- [x] the method `material_select()` is now `formSelect()`. _I added support for it as well as made it backwards compatible_
- [x] the method `pickadate()` is now `datepicker()`. _I added support for it as well as made it backwards compatible_