### PR TITLE
helper-text class for hints

### DIFF
--- a/lib/generators/simple_form/materialize/templates/config/initializers/simple_form_materialize.rb
+++ b/lib/generators/simple_form/materialize/templates/config/initializers/simple_form_materialize.rb
@@ -16,7 +16,7 @@ SimpleForm.setup do |config|
     b.use :input
     b.use :label
     b.use :error, wrap_with: { tag: 'small', class: 'error-block red-text text-darken-1' }
-    b.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'span', class: 'helper-text' }
   end
 
   config.wrappers :materialize_text, tag: 'div', class: 'input-field col', error_class: 'has-error' do |b|
@@ -26,10 +26,10 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :input, class: 'materialize-textarea' 
+    b.use :input, class: 'materialize-textarea'
     b.use :label
     b.use :error, wrap_with: { tag: 'small', class: 'error-block red-text text-darken-1' }
-    b.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'span', class: 'helper-text' }
   end
 
   config.wrappers :materialize_boolean, tag: 'p', class: 'col', error_class: 'has-error' do |b|
@@ -39,7 +39,7 @@ SimpleForm.setup do |config|
     b.use :input
     b.use :label
     b.use :error, wrap_with: { tag: 'small', class: 'error-block red-text text-darken-1' }
-    b.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'span', class: 'helper-text' }
   end
 
   config.wrappers :materialize_toggle, tag: 'p', class: 'col switch', error_class: 'has-error' do |b|
@@ -47,13 +47,13 @@ SimpleForm.setup do |config|
     b.optional :readonly
 
     b.use :label
-    b.wrapper tag: 'label' do |ba| 
+    b.wrapper tag: 'label' do |ba|
       ba.use :input
       ba.use :tag, tag: 'span', class: 'lever'
     end
-    
+
     b.use :error, wrap_with: { tag: 'small', class: 'error-block red-text text-darken-1' }
-    b.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'span', class: 'helper-text' }
   end
 
   config.wrappers :materialize_radio_and_checkboxes, tag: 'div', class: 'col', error_class: 'has-error' do |b|
@@ -62,13 +62,13 @@ SimpleForm.setup do |config|
     b.use :label
     b.use :input
     b.use :error, wrap_with: { tag: 'small', class: 'error-block red-text text-darken-1' }
-    b.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'span', class: 'helper-text' }
   end
 
   config.wrappers :materialize_file_input, tag: 'div', class: 'file-field input-field col', error_class: 'has-error' do |b|
     b.use :html5
 
-    b.wrapper tag: :div, class: 'btn' do |ba| 
+    b.wrapper tag: :div, class: 'btn' do |ba|
       ba.use :tag, tag: :span, text: :label_text
       ba.use :input
     end
@@ -78,13 +78,13 @@ SimpleForm.setup do |config|
     end
 
     b.use :error, wrap_with: { tag: 'small', class: 'error-block red-text text-darken-1' }
-    b.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'span', class: 'helper-text' }
   end
 
   config.wrappers :materialize_multiple_file_input, tag: 'div', class: 'file-field input-field col', error_class: 'has-error' do |b|
     b.use :html5
-    
-    b.wrapper tag: :div, class: 'btn' do |ba| 
+
+    b.wrapper tag: :div, class: 'btn' do |ba|
       ba.use :tag, tag: :span, text: :label_text
       ba.use :input, multiple: true
     end
@@ -94,7 +94,7 @@ SimpleForm.setup do |config|
     end
 
     b.use :error, wrap_with: { tag: 'small', class: 'error-block red-text text-darken-1' }
-    b.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'span', class: 'helper-text' }
   end
 
   config.default_wrapper = :materialize_form


### PR DESCRIPTION
Hello!

I use a form with a hint like this:

`<%= f.input :password, required: true, hint: "6 characters minimum" %>`

At the moment hints are displayed within  a span with the class `help-block`.
Which looks like this with error:

<img width="1013" alt="bildschirmfoto 2018-10-17 um 20 56 22" src="https://user-images.githubusercontent.com/247116/47113315-fa1d9d80-d258-11e8-9388-1c88cebd385c.png">

According to the example on https://materializecss.com/text-inputs.html, hints or helper texts use the class `helper-text`
`<span class="helper-text" data-error="wrong" data-success="right">Helper text</span>`

This PR replaces the class `help-block` with `helper-text`
Which then looks like this with error:

<img width="1020" alt="bildschirmfoto 2018-10-17 um 21 05 44" src="https://user-images.githubusercontent.com/247116/47113584-b7a89080-d259-11e8-851f-bf664d49bfbf.png">

